### PR TITLE
Update copyright date range to include 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017 NetApp Inc.
+Copyright (c) 2015-2019 NetApp Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted (subject to the limitations in the disclaimer below) provided that the following conditions are met:


### PR DESCRIPTION
Only changing the date range for the copyright notice, It's a minor point, but sometimes these minor things can be important, also sometimes people look at the copyright notice to see the last time it had a significant update.