### PR TITLE
Prefix endpoint IPs in examples with https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Usage of ./s3tester:
 
 ## Writing objects into a bucket
 
-    ./s3tester -concurrency=128 -size=20000000 -operation=put -requests=20000 -endpoint="10.96.105.5:8082" -prefix=3
+    ./s3tester -concurrency=128 -size=20000000 -operation=put -requests=20000 -endpoint="https://10.96.105.5:8082" -prefix=3
 
 - Starts writing objects into the default bucket "test".
 - The bucket needs to be created prior to running s3tester.
@@ -123,7 +123,7 @@ Usage of ./s3tester:
 - Replace the sample IP/port combination with the one you are using.
 
 ## Reading objects from a bucket (and other operations)
-    ./s3tester -concurrency=128 -operation=get -requests=200000 -endpoint="10.96.105.5:8082" -prefix=3
+    ./s3tester -concurrency=128 -operation=get -requests=200000 -endpoint="https://10.96.105.5:8082" -prefix=3
 
 - Matches the request above and will read the same objects written in the same sequence.
 - If you use the `randget` operation the objects will be read in random order simulating a random-access workload.


### PR DESCRIPTION
The two examples don't work without it. 

```
s3tester -concurrency=20 -size=300000 -operation=get -requests=100 -endpoint="10.1.1.1:8082" -prefix=3 -bucket=s3tester 
2019/06/11 01:24:29 URL "10.1.1.1:8082" is not a valid endpoint
```