### PR TITLE
Add S3 Fanout support

### DIFF
--- a/replay.go
+++ b/replay.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"hash/fnv"
 	"log"
 	"math"
@@ -12,6 +9,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 type s3op struct {
@@ -211,7 +212,7 @@ func sendS3op(op s3op, params *workloadParams, endpoint string, region string) {
 func createBucket(currentBuckets map[string]bool, bucket string, endpoint string, region string, credential *credentials.Credentials) error {
 	httpClient := MakeHTTPClient()
 
-	svc := MakeS3Service(httpClient, int(0), int(0), endpoint, region, "", credential)
+	svc := MakeS3Service(httpClient, int(0), int(0), endpoint, region, "", credential, 0) // set fanout=0 when creating buckets to dismiss HTTP Header
 
 	// check for bucket existence
 	_, err := svc.CreateBucket(&s3.CreateBucketInput{Bucket: aws.String(bucket),

--- a/s3tester.go
+++ b/s3tester.go
@@ -664,12 +664,15 @@ func MakeS3Service(hclient *http.Client, retrySleep, retries int, endpoint, regi
 	svc.Client.Handlers.Send.PushFront(func(r *request.Request) {
 		userAgent := userAgentString + r.HTTPRequest.UserAgent()
 		r.HTTPRequest.Header.Set("User-Agent", userAgent)
-		if ucopies > 0 && r.Operation.HTTPMethod == "PUT" {
-			r.HTTPRequest.Header.Add("X-Fanout-Copy-Count", fmt.Sprintf("%d", ucopies))
+		if ucopies >= 0 {
+			if r.Operation.HTTPMethod == "PUT" {
+				r.HTTPRequest.Header.Add("X-Fanout-Copy-Count", fmt.Sprintf("%d", ucopies))
+			}
+			if r.Operation.HTTPMethod == "GET" {
+				r.HTTPRequest.Header.Add("X-Fanout-Copy-Index", fmt.Sprintf("%d", ucopies))
+			}
 		}
-		if ucopies >= 0 && r.Operation.HTTPMethod == "GET" {
-			r.HTTPRequest.Header.Add("X-Fanout-Copy-Index", fmt.Sprintf("%d", ucopies))
-		}
+
 		if consistencyControl != "" {
 			r.HTTPRequest.Header.Set("Consistency-Control", consistencyControl)
 		}


### PR DESCRIPTION
Add (partial) support for S3 Fanout API as described by Cisco here: https://www.cisco.com/c/dam/en/us/td/docs/video/virtualized_video_processing/cloud_object_storage/3-16-1/api-guide/cos-3-16-1-api-guide.pdf

The Fanout API includes calls to create, retrieve, and delete fanout objects and to create, retrieve, and
delete individual copies of content within a fanout object.