### PR TITLE
Clarify size parameter unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Usage of ./s3tester:
     -rr
         Reduced redundancy storage for PUT requests
     -size int
-        Object size. Note that s3tester is not ideal for very large objects as the entire body must be read for v4 signing and the aws sdk does not support v4 chunked. Performance may degrade as size increases due to the use of v4 signing without chunked support (default 30720)
+        Object size. Note that s3tester is not ideal for very large objects as the entire body must be read for v4 signing and the aws sdk does not support v4 chunked. Performance may degrade as size increases due to the use of v4 signing without chunked support (default 30720 bytes)
     -tagging string
         The tag-set for the object. The tag-set must be formatted as such: 'tag1=value1&tage2=value2'. Used for put, puttagging, putget and putget9010r.
     -tier string


### PR DESCRIPTION
It's safer to have this clearly stated than worry whether a run f s3tester will blow the tenant quota