### PR TITLE
fix for issue s3tester panicking when send sigint signal

### DIFF
--- a/s3tester.go
+++ b/s3tester.go
@@ -700,12 +700,14 @@ func setupResultStat(testResult *Result) {
 }
 
 func calcStats(results *Result, concurrency int, elapsedTime time.Duration) {
-	mean := results.elapsedSum / time.Duration(results.Count)
-	results.AverageRequestTime = float64(mean) / float64(time.Millisecond)
-	results.NominalRequestsPerSec = 1.0 / mean.Seconds() * float64(concurrency)
-	results.ActualRequestsPerSec = float64(results.Count) / elapsedTime.Seconds()
-	results.ContentThroughput = float64(results.TotalObjectSize) / 1024 / 1024 / elapsedTime.Seconds()
-	results.AverageObjectSize = float64(results.TotalObjectSize) / float64(results.Count)
+	if results.Count > 0 {
+		mean := results.elapsedSum / time.Duration(results.Count)
+		results.AverageRequestTime = float64(mean) / float64(time.Millisecond)
+		results.NominalRequestsPerSec = 1.0 / mean.Seconds() * float64(concurrency)
+		results.ActualRequestsPerSec = float64(results.Count) / elapsedTime.Seconds()
+		results.ContentThroughput = float64(results.TotalObjectSize) / 1024 / 1024 / elapsedTime.Seconds()
+		results.AverageObjectSize = float64(results.TotalObjectSize) / float64(results.Count)
+	}	
 }
 
 func roundResult(results *Result) {


### PR DESCRIPTION
s3tester is panicking with msg: “panic: runtime error: integer divide by zero” when running with workload.json file containing two tests, when sigint signal is sent to s3tester process.
{
"workload": [
{"size": 512, "concurrency": 32, "operation": "put", "prefix": "testobj", "requests": 150000},
{"size": 512, "concurrency": 32, "operation": "get", "prefix": "testobj", "requests": 150000}
]
}
It seems script is only checking context error (ctx.Err() for signal receive) in the worker and not while when issuing executeSingleTest for each test workload, this is causing 0 operations count for the remaining workload test and resulting in ‘divide by zero exception’ in calcStats.

This PR is to fix this s3tester panic issue due to sigint signal.

Testing Done:
- With out fix issue is always reproduced and s3tester is panicking with sigint signal.
- With the fix there is no more panic observed with sigint signal.

