### PR TITLE
Use inbuilt time conversions rather than doing manual unit changes

### DIFF
--- a/s3tester.go
+++ b/s3tester.go
@@ -692,9 +692,9 @@ func setupResultStat(testResult *Result) {
 	roundResult(testResult)
 	processPercentiles(testResult)
 
+	testResult.TotalElapsedTime = float64(elapsedTime.Milliseconds())
 	minReqTime := time.Duration(testResult.latencies.Min() * 1e4)
 	maxReqTime := time.Duration(testResult.latencies.Max() * 1e4)
-	testResult.TotalElapsedTime = float64(elapsedTime) / float64(time.Millisecond)
 	testResult.MinimumRequestTime = float64(minReqTime) / float64(time.Millisecond)
 	testResult.MaximumRequestTime = float64(maxReqTime) / float64(time.Millisecond)
 }


### PR DESCRIPTION
time.Duration is an int64 in nanoseconds.  S3tester stats reports the duration as (ms), and calculates it by dividing time.Duration by 1000. This is actually microseconds.

Fix this by just using duration.Milliseconds() rather than doing manual conversion.