### PR TITLE
support assume-role credential

### DIFF
--- a/mixed_workload.go
+++ b/mixed_workload.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
-	"github.com/aws/aws-sdk-go/aws/credentials"
 )
 
 type s3op struct {
@@ -40,12 +38,11 @@ type workloadParams struct {
 	// workersChanSlice is an s3 operation channel for each worker
 	workersChanSlice []*workerChan
 	concurrency      int
-	credentials      *credentials.Credentials
 }
 
-func setupWorkloadParams(workerChans []*workerChan, concurrency int, credential *credentials.Credentials) *workloadParams {
+func setupWorkloadParams(workerChans []*workerChan, concurrency int) *workloadParams {
 	keys := make(map[string]uint64)
-	return &workloadParams{hashKeys: keys, workersChanSlice: workerChans, concurrency: concurrency, credentials: credential}
+	return &workloadParams{hashKeys: keys, workersChanSlice: workerChans, concurrency: concurrency}
 }
 
 func closeAllWorkerChannels(workChanSlice []*workerChan) {
@@ -55,7 +52,7 @@ func closeAllWorkerChannels(workChanSlice []*workerChan) {
 }
 
 // SetupOps reads in json file to a struct to determine which s3 operations to generate and then execute
-func SetupOps(args *Parameters, workerChans []*workerChan, credential *credentials.Credentials, decoder *json.Decoder) error {
+func SetupOps(args *Parameters, workerChans []*workerChan, decoder *json.Decoder) error {
 	if _, err := decoder.Token(); err != nil {
 		return err
 	}
@@ -67,7 +64,7 @@ func SetupOps(args *Parameters, workerChans []*workerChan, credential *credentia
 		return errors.New("Incorrect workload type specified, must be 'mixedWorkload'")
 	}
 
-	workloadParams := setupWorkloadParams(workerChans, args.Concurrency, credential)
+	workloadParams := setupWorkloadParams(workerChans, args.Concurrency)
 	MixedWorkload(args, workloadParams, decoder)
 	return nil
 }


### PR DESCRIPTION
Support assume-role credential via ENV or shared credential file.

To use assume-role credential, you must specify:
- role-arn
- credential (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY) for assuming role
- role_session_name (optional)

This change moves credential retrieval into an `S3Service` created for each worker. In other words, concurrent workers will each manage its own credential separately. For example, with `-concurrency=3`, 3 workers are spawned and each will retrieve and manage its own temporary credential using assume-role.

Example shared credential file:
```
[joonh]
AWS_ACCESS_KEY_ID = ...
AWS_SECRET_ACCESS_KEY = ...

[joonh-assume-role]
role_arn = arn:aws:iam::123456789012:group/Developers
source_profile = joonh
role_session_name = session_joonh
```