### PR TITLE
Prevent duration and mixed-workload from being used together

### DIFF
--- a/config.go
+++ b/config.go
@@ -452,6 +452,10 @@ func setupParam(args *Parameters) error {
 		if !isRequestsSet && !args.IsDurationOperation() {
 			return fmt.Errorf("Using duration without requests is not supported for operation %q", args.Operation)
 		}
+
+		if args.MixedWorkload != "" {
+			return errors.New("Duration not supported for mixed-workload")
+		}
 	}
 
 	if args.Wait < 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -239,6 +239,15 @@ func TestNotAllowDurationAndUnsupportedOps(t *testing.T) {
 	}
 }
 
+func TestNotAllowDurationAndMixedWorkloadOps(t *testing.T) {
+	cmdline := generateValidCmdlineSetting("-duration=1", "-mixed-workload=/path/to/the-workload-file.json")
+	_, err := parse(cmdline)
+
+	if err == nil {
+		t.Fatalf("duration and mixed-workload cannot both be set")
+	}
+}
+
 func TestRepeatMustBeGreaterThanZero(t *testing.T) {
 	cmdline := generateValidCmdlineSetting("-repeat=-1")
 	_, err := parse(cmdline)


### PR DESCRIPTION
#42 

Adding a small check to prevent -duration and -mixed-workload from being used together which results in an unexpected behaviour.