### PR TITLE
Version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## v3.1.1
+### Added
+- support for AssumeRole credential
+
+### Changed
+- fixed panic that could occur when interrupted by SIGINT
+- fixed reported average object size incorrect when requests fail
+- prevent incompatible duration and mixed-workload arguments from being used together
+
 ## v3.1.0
 ### Added
 - environment variable S3TESTER_PRINT_RESPONSE_HEADERS can be specified to print specific response header values when request fails


### PR DESCRIPTION
This is just summarizing the changes since the last version bump in the CHANGELOG file. The new release tag for v3.1.1 should be added on this.