### PR TITLE
fix GET object range-read request with bytes=0-0 not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## v3.2.2
+
+### Changed
+- Fixed a bug in validation of range-based arguments
+- Fixed some incorrect text for uniformDist
+
 ## v3.2.1
 ### Added
 - Precompute the body and MD5 for S3 PUTs and share the data block for all workers. This speeds up performance by 4x depending on object size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Fixed a bug in validation of range-based arguments
 - Fixed some incorrect text for uniformDist
+- Fix a bug with uniformDist introduced in 3.2.1
 
 ## v3.2.1
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ export AWS_SECRET_ACCESS_KEY=VInXxOfGtEIwVck4AdtUDavmJf/qt3jaJEAvSKZO
 | tagging | string | The tag-set for the object. The tag-set must be formatted as such: `'tag1=value1&tag2=value2'`. Used for `put`, `puttagging`, `putget` and `putget9010r` |
 | tagging-directive | string | Specifies whether the object tag-set is copied from the source object or if it is replaced with the tag-set provided in the object copy request. Value must be one of 'COPY' or 'REPLACE'. Default: `COPY` |
 | tier | string | The retrieval option for restoring an object. One of `expedited`, `standard`, or `bulk`. AWS default option is standard if not specified. Default: `standard` |
-| uniformDist | string | Generates a uniform distribution of object sizes given a min-max size. Allowed values: `10` to `20` |
+| uniformDist | string | Generates a uniform distribution of object sizes given a min-max size (inclusive). uniformDist overrides `size`. Ex.: Use `-uniformDist=1000-2000` to generate an object between 1000 and 2000 bytes in size. |
 | verify | int | Verify the retrieved data on a get operation. `0`: disable verify (default); `1`: normal put data, `2`: multipart put data. If verify equals `2`, partsize is required (default `partsize` is `5242880` bytes) |
 | workload | string | File path to a JSON file that describes a workload to be run. The file is parsed with the Go template package and must produce JSON that is valid according to the workload schema |
 

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ const (
 
 	randomRangeWithoutGetErr    = "the operation type for random-range must be 'get'"
 	randomRangeWithRangeErr     = "random-range and range cannot be set at the same time"
-	randomRangeInvalidMinMaxErr = "random-range must be in the form '<min>-<max>/<size>', where min >= 0, max > 0, and min < max"
+	randomRangeInvalidMinMaxErr = "random-range must be in the form '<min>-<max>/<size>', where min >= 0, max >= 0, and min <= max"
 	randomRangeInvalidSizeErr   = "random-range must be in the form '<min>-<max>/<size>', where size > 0 and size <= max-min+1"
 	randomRangeInvalidFormat    = "random-range must be in the form '<min>-<max>/<size>'"
 )
@@ -290,7 +290,7 @@ Note: Requests are generated in the same order that you specify operations. That
 	flags.StringVar(&params.Tagging, "tagging", "", "The tag-set for the object. The tag-set must be formatted as such: 'tag1=value1&tag2=value2'. Used for put, puttagging, putget and putget9010r.")
 	flags.StringVar(&params.TaggingDirective, "tagging-directive", directiveCopy, "Specifies whether the object tag-set is copied from the source object or if it is replaced with the tag-set provided in the object copy request. Value must be one of 'COPY' or 'REPLACE'")
 	flags.StringVar(&params.Tier, "tier", "standard", "The retrieval option for restoring an object. One of expedited, standard, or bulk. AWS default option is standard if not specified")
-	flags.StringVar(&params.UniformDist, "uniformDist", "", "Generates a uniform distribution of object sizes given a min-max size (10-20)")
+	flags.StringVar(&params.UniformDist, "uniformDist", "", "Generates a uniform distribution of object sizes given a min-max size (inclusive). uniformDist overrides -size. Ex.: Use -uniformDist=1000-2000 to generate an object between 1000 and 2000 bytes in size.")
 	flags.IntVar(&params.Verify, "verify", 0, "Verify the retrieved data on a get operation (0=disable verify(default), 1=normal put data, 2=multipart put data). If verify=2, partsize is required and default partsize is set to 5242880.")
 
 	flags.Usage = func() {
@@ -567,7 +567,7 @@ func setupParam(args *Parameters) error {
 
 	args.min, args.max, err = extractRangeMinMax(args.UniformDist)
 	if err != nil {
-		return errors.New("uniformDist must be in form 'min-max', where min and max are > 0, min < max")
+		return errors.New("uniformDist must be in form 'min-max', where min and max are >= 0, min <= max")
 	}
 
 	// validate random-range
@@ -646,8 +646,8 @@ func extractRangeMinMax(arg string) (min int64, max int64, err error) {
 	}
 
 	max, err = strconv.ParseInt(boundaries[1], 10, 64)
-	if err != nil || max <= 0 {
-		return 0, 0, errors.New("max must be > 0 and an integer")
+	if err != nil || max < 0 {
+		return 0, 0, errors.New("max must be >= 0 and an integer")
 	}
 
 	if min > max {

--- a/config.go
+++ b/config.go
@@ -121,7 +121,7 @@ func NewParameters() *Parameters {
 }
 
 func (params *Parameters) hasRandomSize() bool {
-	return params.max != 0 && params.min != 0
+	return params.max != -1 && params.min != -1
 }
 
 func (params *Parameters) hasRandomRange() bool {
@@ -584,6 +584,9 @@ func setupParam(args *Parameters) error {
 			return errors.New(randomRangeInvalidFormat)
 		}
 
+		if randomRangeParts[0] == "" {
+			return errors.New(randomRangeInvalidMinMaxErr)
+		}
 		args.randomRangeMin, args.randomRangeMax, err = extractRangeMinMax(randomRangeParts[0])
 		if err != nil {
 			return errors.New(randomRangeInvalidMinMaxErr)
@@ -621,7 +624,7 @@ func setupParam(args *Parameters) error {
 
 	// Precompute object body block for PUT operations. This avoids data generation for each PUT.
 	// Keep multipart put as unique objects for each object. The bodies are shared between parts so this already has some optimization.
-	if args.Operation == "put" && args.Size > 0 && args.Prefix != "" {
+	if args.Operation == "put" && args.Size > 0 && args.Prefix != "" && args.UniformDist != "" {
 		if err := args.PreallocatePutBody(); err != nil {
 			return fmt.Errorf("preallocating put body failed: %v", err)
 		}
@@ -632,7 +635,7 @@ func setupParam(args *Parameters) error {
 
 func extractRangeMinMax(arg string) (min int64, max int64, err error) {
 	if arg == "" {
-		return 0, 0, nil
+		return -1, -1, nil // using "-1" as a sentinel value
 	}
 
 	boundaries := strings.Split(arg, "-")
@@ -651,7 +654,7 @@ func extractRangeMinMax(arg string) (min int64, max int64, err error) {
 	}
 
 	if min > max {
-		return 0, 0, errors.New("max must be larger than min")
+		return 0, 0, errors.New("max must be greater than or equal to min")
 	}
 
 	return min, max, nil

--- a/config_test.go
+++ b/config_test.go
@@ -1135,6 +1135,12 @@ func TestRandomRangeValidation(t *testing.T) {
 		t.Fatalf("invalid random-range should fail with error message: %s", err)
 	}
 
+	cmdline = generateValidCmdlineSetting("-operation=get", "-random-range=/1")
+	_, err = parse(cmdline)
+	if err == nil || err.Error() != randomRangeInvalidMinMaxErr {
+		t.Fatalf("invalid random-range should fail with error message: %s", err)
+	}
+
 	cmdline = generateValidCmdlineSetting("-operation=get", "-random-range=500-600/200")
 	_, err = parse(cmdline)
 	if err == nil || err.Error() != randomRangeInvalidSizeErr {
@@ -1167,7 +1173,7 @@ func TestRandomRangeValidation(t *testing.T) {
 
 	cmdline = generateValidCmdlineSetting("-operation=get", "-random-range=0-0/100")
 	_, err = parse(cmdline)
-	if err == nil || err.Error() != randomRangeInvalidMinMaxErr {
+	if err == nil || err.Error() != randomRangeInvalidSizeErr {
 		t.Fatalf("invalid random-range should fail with error message: %s", err)
 	}
 
@@ -1185,6 +1191,20 @@ func TestRandomRangeValidation(t *testing.T) {
 	if args.randomRangeMax != 100 {
 		t.Fatalf("Expected randomRangeMax: 100, but got: %d", args.randomRangeMax)
 	}
+
+	cmdline = generateValidCmdlineSetting("-operation=get", "-random-range=0-0/1")
+	config, err = parse(cmdline)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %s", err)
+	}
+
+	args = config.worklist[0]
+	if args.randomRangeMin != 0 {
+		t.Fatalf("Expected randomRangeMin: 0, but got: %d", args.randomRangeMin)
+	}
+	if args.randomRangeMax != 0 {
+		t.Fatalf("Expected randomRangeMax: 0, but got: %d", args.randomRangeMax)
+	}
 }
 
 func TestUniformDist(t *testing.T) {
@@ -1195,6 +1215,12 @@ func TestUniformDist(t *testing.T) {
 	}
 
 	cmdline = generateValidCmdlineSetting("-operation=put", "-uniformDist=1000-100000")
+	_, err = parse(cmdline)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %s", err)
+	}
+
+	cmdline = generateValidCmdlineSetting("-operation=put", "-uniformDist=0-100000")
 	_, err = parse(cmdline)
 	if err != nil {
 		t.Fatalf("Expected no error, but got: %s", err)
@@ -1270,6 +1296,12 @@ func TestRangeValidation(t *testing.T) {
 	}
 
 	cmdline = generateValidCmdlineSetting("-operation=get", "-range=bytes=0-10")
+	_, err = parse(cmdline)
+	if err != nil {
+		t.Fatalf("Expected no err, but got %s", err)
+	}
+
+	cmdline = generateValidCmdlineSetting("-operation=get", "-range=bytes=0-0")
 	_, err = parse(cmdline)
 	if err != nil {
 		t.Fatalf("Expected no err, but got %s", err)

--- a/s3tester.go
+++ b/s3tester.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// VERSION is displayed with help, bump when updating
-	VERSION = "3.2.1"
+	VERSION = "3.2.2"
 	// for identifying s3tester requests in the user-agent header
 	userAgentString = "s3tester/"
 


### PR DESCRIPTION
#56

The issue itself is pretty straightforward as suggested in the Issue write-up.
I manual-tested the range based arguments in general (`range`, `random-range`, `uniformDist`) to make sure these were working as expected as there is some overlap in the validation paths.