### PR TITLE
Fix issue causing 400 BadDigest error when uniformDist is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 ### Changed
 - Fix a bug with uniformDist (this was not fixed in 3.2.2)
 
-# Changelog
 ## v3.2.2
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## v3.2.3
+
+### Changed
+- Fix a bug with uniformDist (this was not fixed in 3.2.2)
+
+# Changelog
 ## v3.2.2
 
 ### Changed

--- a/config.go
+++ b/config.go
@@ -624,7 +624,8 @@ func setupParam(args *Parameters) error {
 
 	// Precompute object body block for PUT operations. This avoids data generation for each PUT.
 	// Keep multipart put as unique objects for each object. The bodies are shared between parts so this already has some optimization.
-	if args.Operation == "put" && args.Size > 0 && args.Prefix != "" && args.UniformDist != "" {
+	// Don't use Preallocated PUT body when uniformDist is specified, the randomized size causes MD5 checksum issues
+	if args.Operation == "put" && args.Size > 0 && args.Prefix != "" && args.UniformDist == "" {
 		if err := args.PreallocatePutBody(); err != nil {
 			return fmt.Errorf("preallocating put body failed: %v", err)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -1221,9 +1221,15 @@ func TestUniformDist(t *testing.T) {
 	}
 
 	cmdline = generateValidCmdlineSetting("-operation=put", "-uniformDist=0-100000")
-	_, err = parse(cmdline)
+	config, err := parse(cmdline)
 	if err != nil {
 		t.Fatalf("Expected no error, but got: %s", err)
+	}
+	if len(config.worklist) != 1 {
+		t.Fatalf("Expected parsed config to have 1 set of Parameters")
+	}
+	if config.worklist[0].putBody != nil {
+		t.Fatalf("Expected config to NOT use pre-allocated body")
 	}
 
 	cmdline = generateValidCmdlineSetting("-operation=delete", "-uniformDist=1000-100000")

--- a/s3tester.go
+++ b/s3tester.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// VERSION is displayed with help, bump when updating
-	VERSION = "3.2.2"
+	VERSION = "3.2.3"
 	// for identifying s3tester requests in the user-agent header
 	userAgentString = "s3tester/"
 


### PR DESCRIPTION
My bad.

This should have been fixed on the previous version but the logic check was inverted. Fixing it properly now.